### PR TITLE
fix(tmux): tighten Claude Code Bash pre-tool hook

### DIFF
--- a/tmux/claude-pretool-check.sh
+++ b/tmux/claude-pretool-check.sh
@@ -9,22 +9,50 @@ TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [ -z "$COMMAND" ] && exit 0
 
-# Only check commands that look like they start a server
-echo "$COMMAND" | grep -qE '(pnpm dev|pnpm run dev|npm run dev|npm start|next dev|next start|trigger dev|npx serve|python.*-m.*http\.server|(^|[[:space:]])node[[:space:]]+[^|&;]*server|vite|nuxt dev)' || exit 0
+# Strip quoted strings before pattern-matching so embedded text in heredocs,
+# commit messages, PR bodies, grep patterns, etc. doesn't false-positive.
+# (e.g. `pkill -f "next dev"` shouldn't be treated as starting Next.)
+SCAN=$(echo "$COMMAND" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
+# Only check commands that look like they actually start a server. Anchored
+# at start-of-line or after a shell separator so substrings like "pnpm devops"
+# or "next development" don't match.
+echo "$SCAN" | grep -qE '(^|[[:space:];&|]|^cd[[:space:]][^;]*;[[:space:]]*)(pnpm[[:space:]]+(dev|run[[:space:]]+dev|start)|npm[[:space:]]+(run[[:space:]]+dev|start)|yarn[[:space:]]+(dev|start)|next[[:space:]]+(dev|start)|trigger[[:space:]]+dev|npx[[:space:]]+serve|python[[:space:]]+-m[[:space:]]+http\.server|node[[:space:]]+[^|&;]*server|vite|nuxt[[:space:]]+dev)([[:space:]]|$)' || exit 0
+
+# Resolve our working dir — Claude Code passes it via tool_input.cwd; fall
+# back to $PWD for older harnesses.
+CWD=$(echo "$INPUT" | jq -r '.tool_input.cwd // empty')
+[ -z "$CWD" ] && CWD="$PWD"
 
 # Extract port from the command if specified (e.g., --port 3001)
-CMD_PORT=$(echo "$COMMAND" | grep -oE '(--port|-p)\s*[0-9]+' | grep -oE '[0-9]+' | head -1)
-# Default ports to check
-CHECK_PORTS="${CMD_PORT:-3000}"
+CMD_PORT=$(echo "$COMMAND" | grep -oE '(--port|-p)[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)
+# Default ports to check — covers Next.js (3000) plus our common alt (3100).
+CHECK_PORTS="${CMD_PORT:-3000 3100}"
 
-# Check if any of the target ports are already listening
+# Returns 0 (true) if $1 contains $2 as a prefix, in either direction. Used to
+# tell whether two project trees overlap.
+paths_overlap() {
+  case "$1" in "$2"*) return 0 ;; esac
+  case "$2" in "$1"*) return 0 ;; esac
+  return 1
+}
+
+# Check if any of the target ports are already listening. We only block when
+# the listener belongs to the SAME project (its CWD is in/under ours, or vice
+# versa) — a Next dev server in some other repo on port 3000 is fine.
 CONFLICT=""
 for PORT in $(echo "$CHECK_PORTS" | tr ',' ' '); do
   LISTENER=$(lsof -iTCP:"$PORT" -sTCP:LISTEN -P -n 2>/dev/null | tail -n +2 | head -1)
-  if [ -n "$LISTENER" ]; then
-    PROC_NAME=$(echo "$LISTENER" | awk '{print $1}')
-    PROC_PID=$(echo "$LISTENER" | awk '{print $2}')
-    CONFLICT="${CONFLICT}Port $PORT is in use by $PROC_NAME (PID $PROC_PID). "
+  [ -z "$LISTENER" ] && continue
+  PROC_NAME=$(echo "$LISTENER" | awk '{print $1}')
+  PROC_PID=$(echo "$LISTENER" | awk '{print $2}')
+
+  # Best-effort listener CWD via lsof. -F n prints filenames on lines starting
+  # with 'n'; for the cwd fd that's the absolute path.
+  PROC_CWD=$(lsof -p "$PROC_PID" -a -d cwd -F n 2>/dev/null | awk '/^n/{sub(/^n/,""); print; exit}')
+
+  if [ -n "$PROC_CWD" ] && paths_overlap "$PROC_CWD" "$CWD"; then
+    CONFLICT="${CONFLICT}Port $PORT is in use by $PROC_NAME (PID $PROC_PID, cwd: $PROC_CWD). "
   fi
 done
 


### PR DESCRIPTION
## Summary

Two real bugs in \`tmux/claude-pretool-check.sh\` that have been blocking unrelated Bash commands and triggering on cross-project port conflicts.

### Bug 1 — webserver-detection regex matched quoted text

The regex on the old line 13 ran against the entire \`COMMAND\` string verbatim. That means anything containing the literal substring \"pnpm dev\" / \"next dev\" got flagged as starting a webserver, even when those words appeared inside quotes, heredocs, commit-message bodies, or grep patterns.

Real cases hit this session:

- \`gh pr create --body \"...pnpm dev to test\"\` — the test-plan text in the PR body matched the regex
- \`pkill -f \"next dev\"\` — the quoted argument matched
- \`grep -E 'pnpm dev|next start' file\` — would also have

**Fix**: strip single- and double-quoted content from the command **before** pattern matching, and tighten the regex with anchored shell separators + trailing word boundaries (so \`pnpm devops\`, \`next development\`, etc. don't match either).

### Bug 2 — blocked any port-3000 listener, regardless of project

If anything was on port 3000 — a different project's dev server, a docs preview, anything — the hook would refuse all my Bash commands in this repo. The original intent (per the user) was \"if THIS project already has a webserver, don't start another\" — never implemented.

**Fix**: resolve the listener's cwd via \`lsof -p PID -d cwd\` and only flag a conflict when its directory tree overlaps ours (in either direction, so a child directory triggers too).

### Smaller bits

- Default port list now \`3000 3100\` (covers the common Next.js alt port).
- Falls back to \`\$PWD\` when \`tool_input.cwd\` isn't set on older harnesses.
- **Failure mode is \"allow\"**: if \`lsof\` can't read the listener's cwd (sandboxed processes, containers, etc.), the command is allowed rather than blocked indefinitely. Same default as before — just opt-in to blocking now, not opt-out.

## Test plan

- [ ] Start \`pnpm dev --port 3100\` in your imfin checkout
- [ ] In the same Claude Code session, run a Bash command whose body contains the literal text \"pnpm dev\" inside a heredoc — should be **allowed** (was blocked before)
- [ ] Try \`pkill -f \"next dev\"\` — should be **allowed** (was blocked before)
- [ ] Try \`pnpm dev --port 3100\` again from the same project — should be **blocked** (legitimate same-project conflict)
- [ ] Run a different project's dev server on 3000, then \`pnpm dev --port 3100\` from imfin — should be **allowed** (different project tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)