### PR TITLE
Brewfile + zshrc cleanup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -27,6 +27,7 @@ brew "aria2"                         # parallel downloader
 brew "rclone"                        # rsync for cloud storage (S3, GDrive, etc)
 brew "yt-dlp"                        # YouTube downloader
 brew "mkvtoolnix"                    # MKV video manipulation (mkvmerge etc)
+brew "oven-sh/bun/bun"               # JavaScript runtime + bundler + package manager
 
 # === Data tooling ===
 brew "duckdb"                        # in-process analytics db

--- a/Brewfile
+++ b/Brewfile
@@ -75,10 +75,8 @@ cask "firefox"                       # browser
 cask "ollama"                        # local LLM runner
 cask "keka"                          # archive utility (rar, 7z, etc)
 
-# === Optional: large or infrequent. Uncomment what you need. ===
+# === Optional: uncomment if needed ===
 # cask "vlc"                         # media player (~100MB)
-# cask "libreoffice"                 # office suite (~600MB, slow download)
-# cask "displaylink"                 # DisplayLink dock driver
 # cask "nordvpn"                     # VPN (skip if Tailscale covers your needs)
 # cask "visual-studio-code"          # you mostly use Cursor now
 

--- a/Brewfile
+++ b/Brewfile
@@ -55,7 +55,7 @@ cask "font-hack-nerd-font"           # Hack with nerd-font glyphs (terminal)
 cask "font-symbols-only-nerd-font"   # only the nerd-font icons, used by yazi
 cask "sf-symbols"                    # Apple symbol library, used by Sketchybar
 
-# === Apps (move from manual installs to brew) ===
+# === Apps ===
 cask "1password"                     # password manager
 cask "raycast"                       # Spotlight replacement
 cask "obsidian"                      # knowledge base / notes
@@ -63,7 +63,6 @@ cask "notion"                        # docs / wiki
 cask "slack"                         # chat
 cask "spotify"                       # music
 cask "whatsapp"                      # chat
-cask "vlc"                           # media player
 cask "obs"                           # screen recording / streaming
 cask "tailscale"                     # VPN mesh
 cask "figma"                         # design
@@ -74,9 +73,10 @@ cask "google-chrome"                 # browser
 cask "firefox"                       # browser
 cask "ollama"                        # local LLM runner
 cask "keka"                          # archive utility (rar, 7z, etc)
-cask "libreoffice"                   # office suite (open .docx etc)
 
-# === Optional / hardware-specific. Uncomment if you still need them. ===
+# === Optional: large or infrequent. Uncomment what you need. ===
+# cask "vlc"                         # media player (~100MB)
+# cask "libreoffice"                 # office suite (~600MB, slow download)
 # cask "displaylink"                 # DisplayLink dock driver
 # cask "nordvpn"                     # VPN (skip if Tailscale covers your needs)
 # cask "visual-studio-code"          # you mostly use Cursor now

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ ensure_brew() {
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
   eval "$(/opt/homebrew/bin/brew shellenv)"
+  brew update
 }
 
 # --- subcommands ---------------------------------------------------------
@@ -32,7 +33,12 @@ ensure_brew() {
 install_apps() {
   echo ">>> apps (brew bundle)"
   ensure_brew
-  brew bundle --file="$DOTFILES/Brewfile"
+  # --no-lock: skip Brewfile.lock.json generation
+  # Allow partial failures (a single cask download blip won't abort the whole run)
+  brew bundle --file="$DOTFILES/Brewfile" --no-lock || {
+    echo ""
+    echo "WARNING: brew bundle had failures. Run 'brew bundle --file=~/.dotfiles/Brewfile' to retry failed items."
+  }
 }
 
 install_defaults() {

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -4,8 +4,8 @@ autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 eval "$(starship init zsh)"
 export PATH="$HOME/.local/bin:$PATH"
-eval "$(duckman completion zsh)"
-export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
+# duckman: DuckDB version manager, installed via curl not brew
+command -v duckman >/dev/null && eval "$(duckman completion zsh)"
 
 
 eval "$(atuin init zsh)"
@@ -27,7 +27,7 @@ export PATH="/Applications/Cursor.app/Contents/Resources/app/bin:$PATH"
 
 
 # opencode
-export PATH=/Users/mehdio/.opencode/bin:$PATH
+export PATH="$HOME/.opencode/bin:$PATH"
 alias oc-sonnet='opencode --model openrouter/anthropic/claude-sonnet-4.6'
 alias oc-gpt5='opencode --model openrouter/openai/gpt-5-nano'
 alias oc-gpt54='opencode --model openrouter/openai/gpt-5.4-nano'
@@ -55,7 +55,7 @@ _tmux_repo_status() {
 chpwd_functions+=(_tmux_repo_status)
 
 # bun completions
-[ -s "/Users/mehdio/.bun/_bun" ] && source "/Users/mehdio/.bun/_bun"
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
 # bun
 export BUN_INSTALL="$HOME/.bun"


### PR DESCRIPTION
## Summary

Fixes found while verifying all 59 Brewfile entries resolve cleanly (they do).

**Brewfile**
- Move `libreoffice` (~600MB) and `vlc` to optional commented section — large downloads were causing `brew bundle` to fail and abort the rest of the install via `set -e`
- Drop `libreoffice` and `displaylink` entirely (not needed)
- Add `brew update` in `ensure_brew` so the formula index is fresh before bundling
- Handle `brew bundle` non-zero exit gracefully: print a retry hint instead of hard-aborting the full install
- Add `oven-sh/bun/bun` (was installed manually, tap resolves cleanly)

**zshrc**
- Guard `duckman` eval with `command -v` — duckman installs via curl, not brew; without the guard it errors on a fresh machine
- Remove orphan `postgresql@17` PATH entry (not installed, not in Brewfile)
- Fix two hardcoded `/Users/mehdio` paths (`opencode` PATH and bun completions source) — replace with `$HOME`