### PR TITLE
macos: disable Spotlight shortcuts for Raycast

### DIFF
--- a/macos.sh
+++ b/macos.sh
@@ -108,6 +108,17 @@ defaults write com.apple.finder DisableAllAnimations -bool true
 defaults write com.apple.spaces spans-displays -bool false
 
 
-# --- 8. Apply ------------------------------------------------------------
+# --- 8. Spotlight --------------------------------------------------------
+
+# Disable Spotlight search shortcut (Cmd+Space) — freed for Raycast
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled false" \
+  "$HOME/Library/Preferences/com.apple.symbolichotkeys.plist" 2>/dev/null || true
+
+# Disable Spotlight window shortcut (Cmd+Option+Space)
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:65:enabled false" \
+  "$HOME/Library/Preferences/com.apple.symbolichotkeys.plist" 2>/dev/null || true
+
+
+# --- 9. Apply ------------------------------------------------------------
 killall Dock Finder SystemUIServer 2>/dev/null || true
-echo "Done. Some changes (menu bar, key repeat) need a logout to fully apply."
+echo "Done. Some changes (menu bar, key repeat, Spotlight shortcuts) need a logout to fully apply."


### PR DESCRIPTION
## Summary

Adds Spotlight shortcut disable to `macos.sh` so Cmd+Space is free for Raycast on a fresh setup.

Uses `PlistBuddy` on `com.apple.symbolichotkeys.plist` (keys 64 and 65) rather than `defaults write`, which is more reliable for nested plist structures. Both calls are guarded with `|| true` so they are safe to re-run even if the keys don't exist yet.

Requires logout to fully apply (noted in the done message).