### PR TITLE
fix: make batnas Continuity handoff receive safely

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -149,9 +149,11 @@ Create a 1Password item named `herdr-continuity` with `database-url` and
 and encrypted locally; searchable message projections remain plaintext in
 PostgreSQL by design.
 
-`HERDR_CONTINUITY_AUTO_SYNC` defaults to `0` in the isolated template. Change
-it to `1` only after the dedicated Neon project has sufficient storage, then
-rerun the continuity installer or remove the cached continuity env file.
+`HERDR_CONTINUITY_AUTO_SYNC` is enabled for the upgraded Neon project. Scheduled
+fallback sync runs only from 07:00 to 23:00 local time; explicit handoffs and
+Claude Stop-hook pushes are not restricted by that window. Remote handoff
+receive runs through the same isolated wrapper so it can load the shared
+encryption key from 1Password and fail safely when credentials are unavailable.
 
 ---
 

--- a/herdr-continuity/config.toml
+++ b/herdr-continuity/config.toml
@@ -1,10 +1,6 @@
 vault = "~/Documents/mehdio_sb"
 archive_dir = "~/.local/share/herdr-continuity/archives"
 
-[machines.macbook]
-ssh = "macbook"
-repo_root = "~/repos"
-
-[machines.mac-mini]
-ssh = "mac-mini"
+[machines.batnas]
+ssh = "batnas"
 repo_root = "~/repos"

--- a/scripts/herdr-continuity-sync.sh
+++ b/scripts/herdr-continuity-sync.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 state_dir="$HOME/.local/share/herdr-continuity"
 env_file="/tmp/.herdr-continuity-env-$(id -u)"
 mkdir -p "$state_dir"
+receive_mode=0
+[[ "${1:-}" == receive ]] && receive_mode=1
 
 # Keep continuity secrets isolated: a missing item never breaks the main shell
 # environment generated from zsh/env.tpl.
@@ -19,14 +21,28 @@ if [[ ! -s "$env_file" ]] ||
   fi
 fi
 
-[[ -s "$env_file" ]] || exit 0
+if [[ ! -s "$env_file" ]]; then
+  if (( receive_mode )); then
+    echo "Continuity receive failed: 1Password environment is unavailable" >&2
+    exit 1
+  fi
+  exit 0
+fi
 # shellcheck disable=SC1090
 source "$env_file"
 
-[[ "${HERDR_CONTINUITY_AUTO_SYNC:-0}" == 1 ]] || exit 0
+if [[ "${HERDR_CONTINUITY_AUTO_SYNC:-0}" != 1 ]] && (( ! receive_mode )); then
+  exit 0
+fi
 
 binary="${HERDR_CONTINUITY_BIN:-$HOME/.cargo/bin/herdr-continuity}"
-[[ -x "$binary" ]] || exit 0
+if [[ ! -x "$binary" ]]; then
+  if (( receive_mode )); then
+    echo "Continuity receive failed: $binary is not installed" >&2
+    exit 1
+  fi
+  exit 0
+fi
 
 if (( $# == 0 )); then
   current_hour=$(date +%H)


### PR DESCRIPTION
## Summary
- make batnas the single outbound Continuity handoff target
- load the shared encryption key through the isolated 1Password wrapper on receive
- fail explicit receives when credentials or the binary are unavailable
- add a non-interactive batnas-herdr SSH target without replacing existing SSH config
- add hb as the one-command native Herdr remote attach
- document the active Neon schedule and receiver behavior

## Validation
- bash and zsh syntax validation passed
- OpenSSH resolves batnas-herdr with no TTY and no forced remote command
- live Tailscale SSH reached batcave.local through the new alias
- explicit receive with a missing bundle fails non-zero instead of silently succeeding
- Continuity 0.2.2 passed rustfmt, clippy with warnings denied, and all 11 tests

This is the follow-up to merged PR #22; final merge remains a human action.