### PR TITLE
Add safe portable Codex workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Public repository safety
+
+When these instructions are loaded from the dotfiles repository itself, that repository is public. In any other public repository, treat every tracked file and proposed diff as publicly visible.
+
+- Never commit credentials, API keys, access tokens, cookies, private keys, signed URLs, connection strings, account identifiers, or secret-bearing environment files.
+- Never commit concrete `op://` references. Commit placeholder `.example` templates and keep real vault, item, field, and account identifiers in machine-local files.
+- Never commit machine-local trust or authorization state, including approval hashes, hook trust caches, generated auth files, or one-off command approvals.
+- Keep portable defaults separate from mutable runtime configuration. Prefer sanitized templates or base files over symlinking stateful application configs.
+- Avoid absolute home-directory paths and private infrastructure details unless they are intentionally public and required by the configuration.
+- Before committing or pushing, inspect the exact staged diff and scan it for likely secrets and sensitive paths.
+- Stage explicit paths or hunks. Do not use broad staging such as `git add -A` when unrelated changes are present.
+- If a value may be sensitive or its purpose is unclear, leave it untracked and ask before including it.
+- Before staging, committing, pushing, or creating/updating a pull request, prepare and validate the complete local diff and present it to the user for review.
+- Do not take any of those actions until the user explicitly approves that local diff.
+- After approval, verify that the staged diff contains only the reviewed paths and hunks.
+
+# Pull-request safety
+
+- Never merge a pull request on the user's behalf, even when explicitly asked.
+- Never enable auto-merge or add a pull request to a merge queue.
+- Stop at green and merge-ready, provide the pull-request URL, and leave the final UI review and merge exclusively to the user.
+
+# Local diff review
+
+- When Lumen is available, prefer `lumen diff` as the interactive agent-to-human review surface. Use `lumen diff --watch` while changes are still being iterated.
+- Launch Lumen so its stdout is captured by the agent. Treat annotations returned with Lumen's `s` action as user feedback to address.
+- Lumen annotations, marking files viewed, closing Lumen, or returning no annotations do not constitute approval to stage, commit, push, or create/update a pull request. Require the user's explicit approval in the conversation.
+- Do not configure Lumen AI providers or store API keys unless the user explicitly requests it. The diff viewer and annotation workflow do not require AI credentials.

--- a/Brewfile
+++ b/Brewfile
@@ -11,6 +11,7 @@ brew "bash"                          # newer bash (system bash is stuck on 3.2)
 brew "starship"                      # prompt (Pastel Powerline preset)
 brew "atuin"                         # shell history sync across machines
 brew "gh"                            # GitHub CLI
+brew "jnsahaj/lumen/lumen"          # terminal diff review + agent annotation handoff
 brew "jq"                            # JSON processor
 brew "fd"                            # fast find replacement
 brew "ripgrep"                       # fast grep replacement (rg)

--- a/README.MD
+++ b/README.MD
@@ -64,7 +64,7 @@ Run a subset via flags:
 ```bash
 ./install.sh --apps          # Homebrew packages from Brewfile
 ./install.sh --defaults      # macOS defaults (runs macos.sh)
-./install.sh --dotfiles      # symlinks for zsh, tmux, ghostty, starship, atuin, claude, borders
+./install.sh --dotfiles      # symlinks for zsh, tmux, ghostty, starship, atuin, Claude, Codex, borders
 ./install.sh --neovim        # clone LazyVim starter
 ./install.sh --sketchybar    # symlink sketchybar config + install custom font
 ./install.sh --aerospace     # symlink aerospace config
@@ -79,7 +79,7 @@ After installation, you may want to:
 1. **Restart your terminal** to apply all shell changes
 2. **Log out and back in** for Aerospace to take effect
 3. **Configure Atuin** by running `atuin login` to sync shell history across machines
-4. **Set up 1Password** — create items referenced in `zsh/env.tpl` (see [Secrets Management](#secrets-management))
+4. **Set up 1Password** — run `./install.sh --dotfiles`, then replace the placeholder references in the private `~/.config/dotfiles/env.tpl` template (see [Secrets Management](#secrets-management))
 
 ---
 
@@ -91,13 +91,13 @@ After installation, you may want to:
 | `install.sh` | Orchestrator with subcommand flags: apps, defaults, dotfiles, neovim, sketchybar, aerospace. |
 | `macos.sh` | macOS `defaults write` settings, one comment per line. Safe to run standalone. |
 | `mise/` | Exact global developer-tool selections and cross-platform lock metadata. |
-| `herdr-continuity/` | Herdr configuration, isolated 1Password template, and launchd definition. |
+| `herdr-continuity/` | Herdr configuration and launchd definition. |
 
 ## What Each Subcommand Does
 
 ### `--apps`
 
-Runs `brew bundle --file=Brewfile`. Installs all CLI tools (neovim, tmux, atuin, fzf, ripgrep, etc.), data tooling (duckdb, libpq), cloud CLIs (aws, gcloud), window manager + status bar (aerospace, sketchybar, hiddenbar, stats), terminal (ghostty), and apps (1Password, Raycast, Obsidian, Notion, Slack, Spotify, Brave, Chrome, Firefox, Cursor, Claude Desktop, etc.).
+Runs `brew bundle --file=Brewfile`. Installs all CLI tools (neovim, tmux, atuin, fzf, ripgrep, Lumen, etc.), data tooling (duckdb, libpq), cloud CLIs (aws, gcloud), window manager + status bar (aerospace, sketchybar, hiddenbar, stats), terminal (ghostty), and apps (1Password, Raycast, Obsidian, Notion, Slack, Spotify, Brave, Chrome, Firefox, Cursor, Claude Desktop, etc.).
 
 ### `--defaults`
 
@@ -115,8 +115,20 @@ Backs up any existing real files in `~` to `~/dotfiles-backup`, then creates sym
 - `~/.config/atuin/config.toml` (Atuin)
 - `~/.config/borders/bordersrc` (Borders)
 - `~/.claude/settings.json` (Claude Code hooks and status line)
+- `~/.claude/CLAUDE.md` (shared agent instructions from the root `AGENTS.md`)
+- `~/.codex/config.toml` (seeded once; managed Chrome DevTools tables synchronized thereafter)
+- `~/.codex/rules/common.rules` (symlinked reviewed command allowlist)
+- `~/.codex/AGENTS.md` (the same shared root agent instructions)
 
 Sets Zsh as the default shell.
+
+Codex keeps mutable project trust, UI state, hook approvals, and machine-specific
+authorization in its local config. On each dotfiles install, the existing file is
+backed up and only the managed Chrome DevTools tables are replaced. All unrelated
+local state is preserved and never enters this public repository. Chrome runs with
+an isolated temporary profile, disabled usage reporting, and disabled CrUX lookups.
+If `~/.codex/config.toml` is itself a symlink, the installer leaves it untouched
+and asks for a manual merge instead of replacing the link.
 
 ### `--neovim`
 
@@ -159,7 +171,13 @@ encryption key from 1Password and fail safely when credentials are unavailable.
 
 ## Secrets Management
 
-Environment variables (API keys, tokens) are injected at first login via [1Password CLI](https://developer.1password.com/docs/cli/) `op inject`. The template `zsh/env.tpl` contains `op://` references that resolve at runtime and are cached for the session.
+Environment variables containing API keys and tokens are injected with [1Password CLI](https://developer.1password.com/docs/cli/) `op inject`. The public `env.tpl.example` contains placeholders only; `./install.sh --dotfiles` seeds one private, mode-`0600` template at `~/.config/dotfiles/env.tpl` and never overwrites it.
+
+`zprofile` and the Continuity wrapper resolve that shared template through `scripts/op-env-cache.sh`. The resolved environment is written atomically to a mode-`0600`, user-specific cache under `XDG_RUNTIME_DIR`, `TMPDIR`, or `/tmp`, expires after 24 hours, and is deleted if refresh fails. Set `OP_ENV_CACHE_TTL` to override the lifetime in seconds.
+
+On first install after this change, existing private `shell-secrets.env.tpl` and `herdr-continuity.env.tpl` files are combined into `env.tpl`. The legacy files are retained so the migration is recoverable and can be removed manually after verification.
+
+Never commit concrete `op://` references: vault, item, field, and account identifiers belong only in the private templates.
 
 ---
 
@@ -236,6 +254,7 @@ A comprehensive list of apps and tools I use for development and productivity.
 |------|-------------|
 | [Claude Desktop](https://claude.ai/download) | Claude AI desktop app |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | AI coding assistant CLI |
+| [Codex](https://openai.com/codex/) | OpenAI coding agent CLI |
 
 ### Window Management & Menu Bar
 
@@ -264,6 +283,7 @@ A comprehensive list of apps and tools I use for development and productivity.
 | [OrbStack](https://orbstack.dev/) | Fast Docker & Linux on macOS |
 | [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html) | Amazon Web Services CLI |
 | [gcloud CLI](https://cloud.google.com/sdk/docs/install) | Google Cloud CLI |
+| [Yazi](https://github.com/sxyazi/yazi) | Terminal file manager, installed from the Brewfile source of truth |
 | [dua](https://github.com/Byron/dua-cli) | Disk usage analyzer |
 
 ### Browsers

--- a/codex/chrome-devtools.toml
+++ b/codex/chrome-devtools.toml
@@ -1,0 +1,71 @@
+# Managed by dotfiles. The temporary browser profile is deleted after each MCP
+# session, keeping approved test interactions separate from personal browsing.
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = [
+  "-y",
+  "chrome-devtools-mcp@1.2.0",
+  "--isolated",
+  "--no-usage-statistics",
+  "--no-performance-crux",
+]
+
+[mcp_servers.chrome-devtools.tools.list_pages]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.select_page]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.close_page]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.new_page]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.navigate_page]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.take_snapshot]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.take_screenshot]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.click]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.fill]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.fill_form]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.type_text]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.press_key]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.wait_for]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.hover]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.drag]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.handle_dialog]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.resize_page]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.list_console_messages]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.list_network_requests]
+approval_mode = "approve"
+
+[mcp_servers.chrome-devtools.tools.get_network_request]
+approval_mode = "approve"

--- a/codex/config.base.toml
+++ b/codex/config.base.toml
@@ -1,0 +1,3 @@
+# Portable Codex defaults. Mutable machine-local state belongs in ~/.codex/config.toml.
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"

--- a/codex/rules/common.rules
+++ b/codex/rules/common.rules
@@ -1,0 +1,46 @@
+# Read-only GitHub inspection.
+prefix_rule(
+    pattern=["gh", "pr", ["view", "list", "checks", "diff", "status"]],
+    decision="allow",
+    justification="Read-only GitHub pull-request inspection",
+)
+prefix_rule(
+    pattern=["gh", "issue", ["view", "list", "status"]],
+    decision="allow",
+    justification="Read-only GitHub issue inspection",
+)
+prefix_rule(
+    pattern=["gh", "run", ["view", "list", "watch"]],
+    decision="allow",
+    justification="Read-only GitHub Actions inspection",
+)
+prefix_rule(
+    pattern=["gh", "workflow", ["view", "list"]],
+    decision="allow",
+    justification="Read-only GitHub workflow inspection",
+)
+prefix_rule(
+    pattern=["gh", "repo", ["view", "list"]],
+    decision="allow",
+    justification="Read-only GitHub repository inspection",
+)
+prefix_rule(
+    pattern=["gh", "release", ["view", "list"]],
+    decision="allow",
+    justification="Read-only GitHub release inspection",
+)
+prefix_rule(pattern=["gh", "status"], decision="allow")
+prefix_rule(pattern=["gh", "auth", "status"], decision="allow")
+prefix_rule(pattern=["gh", "search"], decision="allow")
+
+# Routine verification scripts in trusted projects.
+prefix_rule(
+    pattern=["pnpm", ["build", "test", "lint", "typecheck", "type-check", "check"]],
+    decision="allow",
+    justification="Routine verification scripts in trusted projects",
+)
+prefix_rule(
+    pattern=["pnpm", "run", ["build", "test", "lint", "typecheck", "type-check", "check"]],
+    decision="allow",
+    justification="Routine verification scripts in trusted projects",
+)

--- a/env.tpl.example
+++ b/env.tpl.example
@@ -1,0 +1,13 @@
+# Copy this file to ~/.config/dotfiles/env.tpl and replace only the placeholder
+# 1Password references. Never commit the private copy or resolved secret values.
+
+# Interactive shell
+export motherduck_token="{{ op://YOUR_VAULT/YOUR_ITEM/motherduck_token }}"
+export GEMINI_API_KEY="{{ op://YOUR_VAULT/YOUR_ITEM/gemini_api_key }}"
+export GEMINI_API="$GEMINI_API_KEY"
+export STRAPI_API_KEY="{{ op://YOUR_VAULT/YOUR_ITEM/strapi_api_key }}"
+
+# Herdr Continuity
+export HERDR_CONTINUITY_DATABASE_URL="{{ op://YOUR_VAULT/YOUR_ITEM/database_url }}"
+export HERDR_CONTINUITY_KEY="{{ op://YOUR_VAULT/YOUR_ITEM/encryption_key }}"
+export HERDR_CONTINUITY_AUTO_SYNC=1

--- a/herdr-continuity/env.tpl
+++ b/herdr-continuity/env.tpl
@@ -1,9 +1,0 @@
-# Create a 1Password item named "herdr-continuity" with these fields.
-export HERDR_CONTINUITY_DATABASE_URL="{{ op://Private/herdr-continuity/database-url }}"
-export HERDR_CONTINUITY_KEY="{{ op://Private/herdr-continuity/encryption-key }}"
-# Enable hourly background sync and exact-session Claude Stop-hook sync.
-export HERDR_CONTINUITY_AUTO_SYNC=1
-# Scheduled fallback sync runs only during local working hours. Explicit
-# push/sync commands and handoffs are never restricted by this window.
-export HERDR_CONTINUITY_SYNC_START_HOUR=7
-export HERDR_CONTINUITY_SYNC_END_HOUR=23

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 #   ./install.sh --full           same as no args
 #   ./install.sh --apps           brew bundle from Brewfile
 #   ./install.sh --defaults       macOS defaults (runs macos.sh)
-#   ./install.sh --dotfiles       symlinks (zsh, tmux, ghostty, starship, atuin, claude, borders) + chmods
-#   ./install.sh --neovim         clone LazyVim starter into ~/.config/nvim
+#   ./install.sh --dotfiles       symlinks (zsh, tmux, ghostty, starship, atuin, Claude, Codex, borders) + chmods
+#   ./install.sh --neovim         clone LazyVim starter and link portable plugins
 #   ./install.sh --sketchybar     symlink config + download font + restart service
 #   ./install.sh --aerospace      symlink aerospace.toml
 #   ./install.sh --extras         tools not on brew (duckman)
@@ -84,10 +84,75 @@ install_dotfiles() {
   ln -sfn "$DOTFILES/tmux/open-url.sh"  "$HOME/.tmux/open-url.sh"
   ln -sfn "$DOTFILES/tmux/log-pane.sh"  "$HOME/.tmux/log-pane.sh"
   chmod +x "$DOTFILES/tmux/"*.sh
+  chmod +x "$DOTFILES/scripts/op-env-cache.sh"
+  chmod +x "$DOTFILES/scripts/sync-codex-config.sh"
 
   # Claude Code
   mkdir -p "$HOME/.claude"
   ln -sfn "$DOTFILES/claude/settings.json" "$HOME/.claude/settings.json"
+
+  # Shared agent instructions: one reviewed source for Claude Code and Codex.
+  if [ -f "$HOME/.claude/CLAUDE.md" ] && [ ! -L "$HOME/.claude/CLAUDE.md" ]; then
+    echo "backing up .claude/CLAUDE.md"
+    cp "$HOME/.claude/CLAUDE.md" "$BACKUP_DIR/claude-CLAUDE.md"
+  fi
+  ln -sfn "$DOTFILES/AGENTS.md" "$HOME/.claude/CLAUDE.md"
+
+  # Codex: preserve mutable local state while syncing reviewed portable settings.
+  mkdir -p "$HOME/.codex/rules"
+  if [ ! -e "$HOME/.codex/config.toml" ]; then
+    cp "$DOTFILES/codex/config.base.toml" "$HOME/.codex/config.toml"
+    printf '\n' >> "$HOME/.codex/config.toml"
+    cat "$DOTFILES/codex/chrome-devtools.toml" >> "$HOME/.codex/config.toml"
+    chmod 600 "$HOME/.codex/config.toml"
+  elif [ -L "$HOME/.codex/config.toml" ]; then
+    echo "~/.codex/config.toml is a symlink; leaving its external config unchanged"
+    echo "Merge codex/chrome-devtools.toml into its source manually"
+  else
+    echo "backing up .codex/config.toml"
+    cp "$HOME/.codex/config.toml" "$BACKUP_DIR/codex-config.toml"
+    bash "$DOTFILES/scripts/sync-codex-config.sh" \
+      "$HOME/.codex/config.toml" \
+      "$DOTFILES/codex/chrome-devtools.toml"
+    echo "Updated managed Chrome DevTools settings; preserved other local Codex state"
+  fi
+  if [ -f "$HOME/.codex/rules/common.rules" ] && [ ! -L "$HOME/.codex/rules/common.rules" ]; then
+    echo "backing up .codex/rules/common.rules"
+    cp "$HOME/.codex/rules/common.rules" "$BACKUP_DIR/codex-common.rules"
+  fi
+  ln -sfn "$DOTFILES/codex/rules/common.rules" "$HOME/.codex/rules/common.rules"
+  if [ -f "$HOME/.codex/AGENTS.md" ] && [ ! -L "$HOME/.codex/AGENTS.md" ]; then
+    echo "backing up .codex/AGENTS.md"
+    cp "$HOME/.codex/AGENTS.md" "$BACKUP_DIR/codex-AGENTS.md"
+  fi
+  ln -sfn "$DOTFILES/AGENTS.md" "$HOME/.codex/AGENTS.md"
+
+  # Seed private 1Password templates once. These mutable files must never be
+  # symlinked back into the public dotfiles repository.
+  local private_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles"
+  mkdir -p "$private_config_dir"
+  chmod 700 "$private_config_dir"
+  if [ ! -e "$private_config_dir/env.tpl" ]; then
+    local legacy_shell="$private_config_dir/shell-secrets.env.tpl"
+    local legacy_continuity="$private_config_dir/herdr-continuity.env.tpl"
+    if [ -f "$legacy_shell" ] || [ -f "$legacy_continuity" ]; then
+      local merged_template
+      merged_template=$(mktemp "$private_config_dir/.env.tpl.XXXXXX")
+      if [ -f "$legacy_shell" ]; then
+        cat "$legacy_shell" >> "$merged_template"
+        printf '\n' >> "$merged_template"
+      fi
+      [ ! -f "$legacy_continuity" ] || cat "$legacy_continuity" >> "$merged_template"
+      chmod 600 "$merged_template"
+      mv "$merged_template" "$private_config_dir/env.tpl"
+      echo "Combined legacy private templates into ~/.config/dotfiles/env.tpl"
+      echo "Legacy templates were retained for manual cleanup"
+    else
+      cp "$DOTFILES/env.tpl.example" "$private_config_dir/env.tpl"
+      chmod 600 "$private_config_dir/env.tpl"
+      echo "Created private 1Password environment template; replace its placeholder references"
+    fi
+  fi
 
   # Default shell
   if [ "$SHELL" != "/bin/zsh" ]; then
@@ -103,6 +168,12 @@ install_neovim() {
   else
     echo "~/.config/nvim already exists, skipping clone"
   fi
+
+  # Portable, reviewed plugin specs live in dotfiles; LazyVim runtime state stays local.
+  mkdir -p "$HOME/.config/nvim/lua/plugins"
+  ln -sfn \
+    "$DOTFILES/nvim/lua/plugins/git-review.lua" \
+    "$HOME/.config/nvim/lua/plugins/git-review.lua"
 }
 
 install_sketchybar() {

--- a/nvim/lua/plugins/git-review.lua
+++ b/nvim/lua/plugins/git-review.lua
@@ -1,0 +1,10 @@
+return {
+  {
+    "esmuellert/codediff.nvim",
+    cmd = "CodeDiff",
+    keys = {
+      { "<leader>gd", "<cmd>CodeDiff<cr>", desc = "Git Diff Review" },
+    },
+    opts = {},
+  },
+}

--- a/scripts/herdr-continuity-sync.sh
+++ b/scripts/herdr-continuity-sync.sh
@@ -2,26 +2,13 @@
 set -euo pipefail
 
 state_dir="$HOME/.local/share/herdr-continuity"
-env_file="/tmp/.herdr-continuity-env-$(id -u)"
+template="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/env.tpl"
 mkdir -p "$state_dir"
 receive_mode=0
 [[ "${1:-}" == receive ]] && receive_mode=1
 
-# Keep continuity secrets isolated: a missing item never breaks the main shell
-# environment generated from zsh/env.tpl.
-if [[ ! -s "$env_file" ]] ||
-   [[ $(( $(date +%s) - $(stat -f %m "$env_file" 2>/dev/null || echo 0) )) -gt 86400 ]]; then
-  generated="$env_file.tmp"
-  if op inject --account my.1password.com \
-      -i "$HOME/.dotfiles/herdr-continuity/env.tpl" >"$generated" 2>/dev/null; then
-    chmod 600 "$generated"
-    mv "$generated" "$env_file"
-  else
-    rm -f "$generated"
-  fi
-fi
-
-if [[ ! -s "$env_file" ]]; then
+# Reuse the same injected environment cache as the interactive shell.
+if ! env_file=$(bash "$HOME/.dotfiles/scripts/op-env-cache.sh" "$template" environment 2>/dev/null); then
   if (( receive_mode )); then
     echo "Continuity receive failed: 1Password environment is unavailable" >&2
     exit 1

--- a/scripts/op-env-cache.sh
+++ b/scripts/op-env-cache.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+template="${1:?usage: op-env-cache.sh TEMPLATE CACHE_KEY}"
+cache_key="${2:?usage: op-env-cache.sh TEMPLATE CACHE_KEY}"
+cache_ttl="${OP_ENV_CACHE_TTL:-86400}"
+
+case "$cache_key" in
+  *[!A-Za-z0-9._-]*)
+    echo "Invalid 1Password cache key" >&2
+    exit 2
+    ;;
+esac
+
+case "$cache_ttl" in
+  ''|*[!0-9]*)
+    echo "Invalid 1Password cache TTL" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -r "$template" ]]; then
+  echo "1Password template is missing: $template" >&2
+  exit 1
+fi
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "1Password CLI is unavailable" >&2
+  exit 1
+fi
+
+runtime_root="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}"
+cache_dir="$runtime_root/dotfiles-op-cache-$(id -u)"
+cache_file="$cache_dir/$cache_key.env"
+
+umask 077
+if [[ ! -d "$runtime_root" || -L "$runtime_root" ]]; then
+  echo "Unsafe runtime directory: $runtime_root" >&2
+  exit 1
+fi
+if [[ -L "$cache_dir" ]]; then
+  echo "Unsafe 1Password cache directory" >&2
+  exit 1
+fi
+mkdir -p "$cache_dir"
+chmod 700 "$cache_dir"
+
+expected_owner=$(id -u)
+cache_owner=$(stat -f %u "$cache_dir" 2>/dev/null || stat -c %u "$cache_dir" 2>/dev/null || echo unknown)
+if [[ "$cache_owner" != "$expected_owner" ]]; then
+  echo "1Password cache directory has the wrong owner" >&2
+  exit 1
+fi
+
+if [[ -L "$cache_file" ]]; then
+  echo "Unsafe 1Password cache file" >&2
+  exit 1
+fi
+[[ ! -f "$cache_file" ]] || chmod 600 "$cache_file"
+
+now=$(date +%s)
+mtime=0
+if [[ -f "$cache_file" ]]; then
+  mtime=$(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null || echo 0)
+fi
+
+generated=""
+cleanup() {
+  [[ -z "$generated" || ! -e "$generated" ]] || rm -f -- "$generated"
+}
+trap cleanup EXIT HUP INT TERM
+
+if [[ ! -s "$cache_file" ]] || (( mtime > now || now - mtime > cache_ttl )); then
+  generated=$(mktemp "$cache_dir/$cache_key.env.tmp.XXXXXX")
+  if op inject -i "$template" >"$generated" 2>/dev/null; then
+    chmod 600 "$generated"
+    mv -f "$generated" "$cache_file"
+    generated=""
+  else
+    rm -f -- "$generated" "$cache_file"
+    generated=""
+    echo "1Password injection failed for $template" >&2
+    exit 1
+  fi
+fi
+
+printf '%s\n' "$cache_file"

--- a/scripts/sync-codex-config.sh
+++ b/scripts/sync-codex-config.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:?usage: sync-codex-config.sh TARGET_CONFIG MANAGED_FRAGMENT}"
+fragment="${2:?usage: sync-codex-config.sh TARGET_CONFIG MANAGED_FRAGMENT}"
+
+if [[ ! -f "$target" || ! -r "$target" ]]; then
+  echo "Codex config is missing or unreadable: $target" >&2
+  exit 1
+fi
+
+if [[ -L "$target" ]]; then
+  echo "Refusing to replace a symlinked Codex config: $target" >&2
+  exit 1
+fi
+
+if [[ ! -f "$fragment" || ! -r "$fragment" ]]; then
+  echo "Managed Codex fragment is missing or unreadable: $fragment" >&2
+  exit 1
+fi
+
+target_dir=$(dirname "$target")
+generated=$(mktemp "$target_dir/.config.toml.XXXXXX")
+cleanup() {
+  [[ -z "${generated:-}" || ! -e "$generated" ]] || rm -f -- "$generated"
+}
+trap cleanup EXIT HUP INT TERM
+
+# Remove the Chrome DevTools tables managed by this repository and the legacy
+# Scenario model-run auto-approval. Preserve every other local setting,
+# including project trust, Scenario's server connection, and hook state.
+awk '
+  /^\[mcp_servers\.("chrome-devtools"|chrome-devtools)(\.tools\.[^]]+)?\][[:space:]]*$/ {
+    skip = 1
+    next
+  }
+  /^\[mcp_servers\.("scenario"|scenario)\.tools\.("model_run"|model_run)\][[:space:]]*$/ {
+    skip = 1
+    next
+  }
+  /^\[/ { skip = 0 }
+  !skip { print }
+' "$target" > "$generated"
+
+printf '\n' >> "$generated"
+cat "$fragment" >> "$generated"
+chmod 600 "$generated"
+mv -f "$generated" "$target"
+generated=""

--- a/zsh/env.tpl
+++ b/zsh/env.tpl
@@ -1,2 +1,0 @@
-export motherduck_token={{ op://Private/dev-batbook-shell/motherduck_token }}
-export GEMINI_API_KEY={{ op://Private/dev-batbook-shell/gemini_api_key }}

--- a/zsh/zprofile.symlink
+++ b/zsh/zprofile.symlink
@@ -1,12 +1,23 @@
 alias v="nvim"
 alias cc="claude"
-# Secrets injected from 1Password — only once per machine boot (cached in tmpfile)
-_OP_CACHE="/tmp/.op-env-$(id -u)"
-if [ ! -f "$_OP_CACHE" ] || [ "$(( $(date +%s) - $(stat -f %m "$_OP_CACHE") ))" -gt 86400 ]; then
-  op inject -i ~/.dotfiles/zsh/env.tpl > "$_OP_CACHE" 2>/dev/null && chmod 600 "$_OP_CACHE"
+
+# Make Homebrew-installed tools available before loading 1Password secrets.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+elif command -v brew >/dev/null 2>&1; then
+  eval "$(brew shellenv)"
 fi
-[ -f "$_OP_CACHE" ] && source "$_OP_CACHE"
-eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# Secrets are injected from a machine-local 1Password template and cached in
+# the private temporary runtime directory for up to 24 hours.
+_OP_TEMPLATE="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/env.tpl"
+if _OP_CACHE=$(bash "$HOME/.dotfiles/scripts/op-env-cache.sh" "$_OP_TEMPLATE" environment 2>/dev/null); then
+  # shellcheck disable=SC1090
+  source "$_OP_CACHE"
+fi
+unset _OP_CACHE _OP_TEMPLATE
 
 
 # AWS


### PR DESCRIPTION
## Summary

- add portable Codex command rules and a managed, pinned, isolated Chrome DevTools MCP configuration
- share public-repository and pull-request safety instructions between Codex and Claude, with Lumen and CodeDiff review tooling
- move 1Password references into one private environment template backed by a hardened temporary cache and recoverable migration

## Validation

- Bash and Zsh syntax checks
- composite TOML parsing and idempotent Codex config synchronization
- cache permission, ownership, TTL, and symlink-defense tests
- staged and committed-tree scans for concrete 1Password references and high-confidence secrets
- git diff whitespace validation